### PR TITLE
Fix Reference Issue with Navbar

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -6,7 +6,7 @@
         <a href="#" class="main-navigation-link" id="about" data-scroll-goto="0">About</a>
         
         {{ if .Site.Params.process.enable }}
-        <a href="#" class="main-navigation-link" data-scroll-goto="2">{{ .Site.Params.process.title }}</a>
+        <a href="#" class="main-navigation-link" data-scroll-goto="1">{{ .Site.Params.process.title }}</a>
         {{ end }}
 
         {{ if .Site.Params.case_studies.enable }}


### PR DESCRIPTION
When clicking My Process on navbar, will now direct to the relevant section instead of incorrectly directing to Case Study.